### PR TITLE
remove ' instead of replacing it with -

### DIFF
--- a/slugify
+++ b/slugify
@@ -25,6 +25,8 @@ to_slug() {
   # Forcing the POSIX local so alnum is only 0-9A-Za-z
   export LANG=POSIX
   export LC_ALL=POSIX
+  #transliterate special chars
+  iconv -f UTF-8 -t ASCII//TRANSLIT |
   # Keep only alphanumeric value
   sed -e 's/[^[:alnum:]]/-/g' |
   # Keep only one dash if there is multiple one consecutively

--- a/slugify
+++ b/slugify
@@ -25,6 +25,8 @@ to_slug() {
   # Forcing the POSIX local so alnum is only 0-9A-Za-z
   export LANG=POSIX
   export LC_ALL=POSIX
+  #replace ' with nothing
+  sed -e "s/[\']//g" |
   # Keep only alphanumeric value
   sed -e 's/[^[:alnum:]]/-/g' |
   # Keep only one dash if there is multiple one consecutively


### PR DESCRIPTION
this might be kind of opinionated, but I like it better if ' is removed instead of replaced, so that e.g. "don't" will be slugified to "dont" instead of "don-t"